### PR TITLE
Add Kafka Credentials to ProviderConfig Secret

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ cover.out
 # ignore IDE folders
 .vscode/
 .idea/
+kubeconfig

--- a/cluster/test/setup.sh
+++ b/cluster/test/setup.sh
@@ -13,7 +13,7 @@ ${KUBECTL} -n upbound-system wait --for=condition=Available deployment --all --t
 
 echo "Creating a default provider config..."
 cat <<EOF | ${KUBECTL} apply -f -
-apiVersion: confluent.upbound.io/v1beta1
+apiVersion: confluent.crossplane.io/v1beta1
 kind: ProviderConfig
 metadata:
   name: default
@@ -24,3 +24,4 @@ spec:
       name: provider-secret
       namespace: upbound-system
       key: credentials
+EOF

--- a/examples/kafkaacl/kafkaacl.yaml
+++ b/examples/kafkaacl/kafkaacl.yaml
@@ -1,0 +1,18 @@
+apiVersion: confluent.crossplane.io/v1alpha1
+kind: KafkaACL
+metadata:
+  name: kafka-acl-confluent-cloud
+spec:
+  deletionPolicy: Delete
+  forProvider:
+    host: '*'
+    kafkaCluster:
+      - id: ${data.confluent_kafka_cluster_id}
+    operation: READ
+    patternType: PREFIXED
+    permission: ALLOW
+    principal: ${data.confluent_principal}
+    resourceName: test-
+    resourceType: TOPIC
+  providerConfigRef:
+    name: default

--- a/examples/providerconfig/providerconfig.yaml
+++ b/examples/providerconfig/providerconfig.yaml
@@ -21,5 +21,8 @@ stringData:
   credentials: |
     {
       "cloud_api_key": "<confluent_api_key_id>",
-      "cloud_api_secret": "<confluent_api_key_secret>
+      "cloud_api_secret": "<confluent_api_key_secret>",
+      "kafka_api_key": "<schema_registry_api_key>",
+      "kafka_api_secret": "<schema_registry_api_secret>",
+      "kafka_rest_endpoint": "<schema_registry_rest_endpoint>"
     }

--- a/examples/providerconfig/secret.yaml.tmpl
+++ b/examples/providerconfig/secret.yaml.tmpl
@@ -7,6 +7,9 @@ type: Opaque
 stringData:
   credentials: |
     {
-      "username": "admin",
-      "password": "t0ps3cr3t11"
+      "cloud_api_key": "admin",
+      "cloud_api_secret": "t0ps3cr3t11",
+      "kafka_api_key": "kafka_admin",
+      "kafka_api_secret": "P@55w0rd",
+      "kafka_rest_endpoint": "https://abc-12345z.region.provider.confluent.cloud:443"
     }

--- a/internal/clients/confluent.go
+++ b/internal/clients/confluent.go
@@ -18,8 +18,11 @@ import (
 
 const (
 	// ProviderConfig secret keys
-	cloudAPIKey    = "cloud_api_key"
-	cloudAPISecret = "cloud_api_secret"
+	cloudAPIKey       = "cloud_api_key"
+	cloudAPISecret    = "cloud_api_secret"
+	kafkaAPIKey       = "kafka_api_key"
+	kafkaAPISecret    = "kafka_api_secret"
+	kafkaRESTEndpoint = "kafka_rest_endpoint"
 
 	// error messages
 	errNoProviderConfig     = "no providerConfigRef provided"
@@ -69,8 +72,11 @@ func TerraformSetupBuilder(version, providerSource, providerVersion string, sche
 
 		// Set credentials in Terraform provider configuration.
 		ps.Configuration = map[string]any{
-			cloudAPIKey:    creds[cloudAPIKey],
-			cloudAPISecret: creds[cloudAPISecret],
+			cloudAPIKey:       creds[cloudAPIKey],
+			cloudAPISecret:    creds[cloudAPISecret],
+			kafkaAPIKey:       creds[kafkaAPIKey],
+			kafkaAPISecret:    creds[kafkaAPISecret],
+			kafkaRESTEndpoint: creds[kafkaRESTEndpoint],
 		}
 		return ps, nil
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

This branch adds kafkaAPIKey, kafkaAPISecret, and kafkaRESTEndpoint to the ProviderConfig secret.  This resolves #18, which affected import of resources after provider-confluent restarted.  See Terraform confluent provider docs for more info about this:
* https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_kafka_acl#import
* https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_kafka_topic#import

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #18 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Successfully ran e2e test with a `kafkaacl` resource against a Confluent Cloud basic cluster.  Built and deployed the changes in this branch to two control planes and verified previously out of sync `kafkaacl` resources are successfully re-synced.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
