### PR TITLE
Add principal reference to RoleBinding resource

### DIFF
--- a/apis/confluent/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/confluent/v1alpha1/zz_generated.deepcopy.go
@@ -2642,11 +2642,6 @@ func (in *RoleBindingInitParameters) DeepCopyInto(out *RoleBindingInitParameters
 		*out = new(string)
 		**out = **in
 	}
-	if in.Principal != nil {
-		in, out := &in.Principal, &out.Principal
-		*out = new(string)
-		**out = **in
-	}
 	if in.RoleName != nil {
 		in, out := &in.RoleName, &out.RoleName
 		*out = new(string)
@@ -2743,6 +2738,16 @@ func (in *RoleBindingParameters) DeepCopyInto(out *RoleBindingParameters) {
 		in, out := &in.Principal, &out.Principal
 		*out = new(string)
 		**out = **in
+	}
+	if in.PrincipalRef != nil {
+		in, out := &in.PrincipalRef, &out.PrincipalRef
+		*out = new(v1.Reference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.PrincipalSelector != nil {
+		in, out := &in.PrincipalSelector, &out.PrincipalSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.RoleName != nil {
 		in, out := &in.RoleName, &out.RoleName

--- a/apis/confluent/v1alpha1/zz_kafkaacl_types.go
+++ b/apis/confluent/v1alpha1/zz_kafkaacl_types.go
@@ -153,7 +153,7 @@ type KafkaACLParameters struct {
 	// The principal for the ACL.
 	// The principal for the ACL.
 	// +crossplane:generate:reference:type=ServiceAccount
-	// +crossplane:generate:reference:extractor=github.com/crossplane-contrib/provider-confluent/config/confluent_kafka_acl.ExtractResourceID()
+	// +crossplane:generate:reference:extractor=github.com/crossplane-contrib/provider-confluent/config/common.ExtractPrincipalID()
 	// +kubebuilder:validation:Optional
 	Principal *string `json:"principal,omitempty" tf:"principal,omitempty"`
 

--- a/apis/confluent/v1alpha1/zz_rolebinding_types.go
+++ b/apis/confluent/v1alpha1/zz_rolebinding_types.go
@@ -23,10 +23,6 @@ type RoleBindingInitParameters struct {
 	// A CRN that specifies the scope and resource patterns necessary for the role to bind.
 	CrnPattern *string `json:"crnPattern,omitempty" tf:"crn_pattern,omitempty"`
 
-	// A principal User to bind the role to, for example, "User:u-111aaa" for binding to a user "u-111aaa", or "User:sa-111aaa" for binding to a service account "sa-111aaa".
-	// The principal User to bind the role to.
-	Principal *string `json:"principal,omitempty" tf:"principal,omitempty"`
-
 	// A name of the role to bind to the principal. See Confluent Cloud RBAC Roles for a full list of supported role names.
 	// The name of the role to bind to the principal.
 	RoleName *string `json:"roleName,omitempty" tf:"role_name,omitempty"`
@@ -59,8 +55,18 @@ type RoleBindingParameters struct {
 
 	// A principal User to bind the role to, for example, "User:u-111aaa" for binding to a user "u-111aaa", or "User:sa-111aaa" for binding to a service account "sa-111aaa".
 	// The principal User to bind the role to.
+	// +crossplane:generate:reference:type=ServiceAccount
+	// +crossplane:generate:reference:extractor=github.com/crossplane-contrib/provider-confluent/config/common.ExtractPrincipalID()
 	// +kubebuilder:validation:Optional
 	Principal *string `json:"principal,omitempty" tf:"principal,omitempty"`
+
+	// Reference to a ServiceAccount to populate principal.
+	// +kubebuilder:validation:Optional
+	PrincipalRef *v1.Reference `json:"principalRef,omitempty" tf:"-"`
+
+	// Selector for a ServiceAccount to populate principal.
+	// +kubebuilder:validation:Optional
+	PrincipalSelector *v1.Selector `json:"principalSelector,omitempty" tf:"-"`
 
 	// A name of the role to bind to the principal. See Confluent Cloud RBAC Roles for a full list of supported role names.
 	// The name of the role to bind to the principal.
@@ -104,7 +110,6 @@ type RoleBinding struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.crnPattern) || (has(self.initProvider) && has(self.initProvider.crnPattern))",message="spec.forProvider.crnPattern is a required parameter"
-	// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.principal) || (has(self.initProvider) && has(self.initProvider.principal))",message="spec.forProvider.principal is a required parameter"
 	// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.roleName) || (has(self.initProvider) && has(self.initProvider.roleName))",message="spec.forProvider.roleName is a required parameter"
 	Spec   RoleBindingSpec   `json:"spec"`
 	Status RoleBindingStatus `json:"status,omitempty"`

--- a/config/common/config.go
+++ b/config/common/config.go
@@ -1,0 +1,32 @@
+package common
+
+import (
+	"fmt"
+
+	xpref "github.com/crossplane/crossplane-runtime/pkg/reference"
+	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
+	"github.com/crossplane/upjet/pkg/resource"
+)
+
+const (
+	SelfPackagePath            = "github.com/crossplane-contrib/provider-confluent/config/common"
+	ExtractPrincipalIDFuncPath = SelfPackagePath + ".ExtractPrincipalID()"
+)
+
+// Extract the identifier of a user to use for
+// principal references
+func ExtractPrincipalID() xpref.ExtractValueFn {
+	return func(mr xpresource.Managed) string {
+		tr, ok := mr.(resource.Terraformed)
+		if !ok {
+			return ""
+		}
+
+		userID := tr.GetID()
+		if len(userID) == 0 {
+			return ""
+		}
+
+		return fmt.Sprintf("User:%v", userID) // append 'User:' infront of the service account ID when resolving 'principal' field.
+	}
+}

--- a/config/confluent_kafka_acl/config.go
+++ b/config/confluent_kafka_acl/config.go
@@ -1,18 +1,8 @@
 package confluent_kafka_acl
 
 import (
-	"fmt"
-
-	xpref "github.com/crossplane/crossplane-runtime/pkg/reference"
-	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
+	"github.com/crossplane-contrib/provider-confluent/config/common"
 	"github.com/crossplane/upjet/pkg/config"
-	"github.com/crossplane/upjet/pkg/resource"
-)
-
-// Constants for custom Extractor function
-var (
-	selfPackagePath     = "github.com/crossplane-contrib/provider-confluent/config/confluent_kafka_acl"
-	extractResourceIDFn = selfPackagePath + ".ExtractResourceID()"
 )
 
 // Configure configures individual resources by adding custom ResourceConfigurators.
@@ -31,18 +21,7 @@ func Configure(p *config.Provider) {
 		// Allows us to reference managedResource ID via spec.forProvider.principal.idSelector
 		r.References["principal"] = config.Reference{
 			Type:      "ServiceAccount",
-			Extractor: extractResourceIDFn,
+			Extractor: common.ExtractPrincipalIDFuncPath,
 		}
 	})
-}
-
-func ExtractResourceID() xpref.ExtractValueFn {
-	return func(mr xpresource.Managed) string {
-		tr, ok := mr.(resource.Terraformed)
-		if !ok {
-			return ""
-		}
-
-		return fmt.Sprintf("User:%v", tr.GetID()) // append 'User:' infront of the service account ID when resolving 'principal' field.
-	}
 }

--- a/config/confluent_role_binding/config.go
+++ b/config/confluent_role_binding/config.go
@@ -1,6 +1,7 @@
 package confluent_role_binding
 
 import (
+	"github.com/crossplane-contrib/provider-confluent/config/common"
 	"github.com/crossplane/upjet/pkg/config"
 )
 
@@ -11,5 +12,11 @@ func Configure(p *config.Provider) {
 		r.ShortGroup = "confluent"
 		r.UseAsync = true
 		r.Kind = "RoleBinding"
+
+		// Allows us to reference managedResource ID via spec.forProvider.principal.idSelector
+		r.References["principal"] = config.Reference{
+			Type:      "ServiceAccount",
+			Extractor: common.ExtractPrincipalIDFuncPath,
+		}
 	})
 }

--- a/examples-generated/confluent/rolebinding.yaml
+++ b/examples-generated/confluent/rolebinding.yaml
@@ -9,5 +9,7 @@ metadata:
 spec:
   forProvider:
     crnPattern: ${data.confluent_organization.demo.resource_name}
-    principal: User:${confluent_service_account.test.id}
+    principalSelector:
+      matchLabels:
+        testing.upbound.io/example-name: test
     roleName: MetricsViewer

--- a/package/crds/confluent.crossplane.io_rolebindings.yaml
+++ b/package/crds/confluent.crossplane.io_rolebindings.yaml
@@ -78,6 +78,79 @@ spec:
                       for binding to a service account "sa-111aaa". The principal
                       User to bind the role to.
                     type: string
+                  principalRef:
+                    description: Reference to a ServiceAccount to populate principal.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: Resolution specifies whether resolution of
+                              this reference is required. The default is 'Required',
+                              which means the reconcile will fail if the reference
+                              cannot be resolved. 'Optional' means this reference
+                              will be a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: Resolve specifies when this reference should
+                              be resolved. The default is 'IfNotPresent', which will
+                              attempt to resolve the reference only when the corresponding
+                              field is not present. Use 'Always' to resolve the reference
+                              on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  principalSelector:
+                    description: Selector for a ServiceAccount to populate principal.
+                    properties:
+                      matchControllerRef:
+                        description: MatchControllerRef ensures an object with the
+                          same controller reference as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: Resolution specifies whether resolution of
+                              this reference is required. The default is 'Required',
+                              which means the reconcile will fail if the reference
+                              cannot be resolved. 'Optional' means this reference
+                              will be a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: Resolve specifies when this reference should
+                              be resolved. The default is 'IfNotPresent', which will
+                              attempt to resolve the reference only when the corresponding
+                              field is not present. Use 'Always' to resolve the reference
+                              on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   roleName:
                     description: A name of the role to bind to the principal. See
                       Confluent Cloud RBAC Roles for a full list of supported role
@@ -101,12 +174,6 @@ spec:
                       scope and resource patterns necessary for the role to bind.
                       A CRN that specifies the scope and resource patterns necessary
                       for the role to bind.
-                    type: string
-                  principal:
-                    description: A principal User to bind the role to, for example,
-                      "User:u-111aaa" for binding to a user "u-111aaa", or "User:sa-111aaa"
-                      for binding to a service account "sa-111aaa". The principal
-                      User to bind the role to.
                     type: string
                   roleName:
                     description: A name of the role to bind to the principal. See
@@ -279,10 +346,6 @@ spec:
               rule: '!(''*'' in self.managementPolicies || ''Create'' in self.managementPolicies
                 || ''Update'' in self.managementPolicies) || has(self.forProvider.crnPattern)
                 || (has(self.initProvider) && has(self.initProvider.crnPattern))'
-            - message: spec.forProvider.principal is a required parameter
-              rule: '!(''*'' in self.managementPolicies || ''Create'' in self.managementPolicies
-                || ''Update'' in self.managementPolicies) || has(self.forProvider.principal)
-                || (has(self.initProvider) && has(self.initProvider.principal))'
             - message: spec.forProvider.roleName is a required parameter
               rule: '!(''*'' in self.managementPolicies || ''Create'' in self.managementPolicies
                 || ''Update'' in self.managementPolicies) || has(self.forProvider.roleName)


### PR DESCRIPTION
### Description of your changes

Currently, the `RoleBinding` resource only supports specifying the principal as a string. The `KafkaACL` resource already has a `spec.forProvider.principalRef/principalSelector` field to reference a `ServiceAccount` resource as the principal.

This PR adds the same feature to the `RoleBinding` resource and refactors the ID extraction function so that it can be reused. The ID function also includes a slight improvement to return an empty string in case the user ID is empty (this seems to happen when the service account is not yet provisioned).

Added fields to `RoleBinding` resource:

```yaml
apiVersion: confluent.crossplane.io/v1alpha1
kind: RoleBinding
spec:
  forProvider:
    principalRef:
    principalSelector:
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

I also have been unable to run `make reviewable test` as I get the same error described here: #22

### How has this code been tested

Tested in a local kind cluster and successfully created role bindings with service account reference in Confluent Cloud.
