### PR TITLE
feat: add IdentityPool resource

### DIFF
--- a/config/confluent_identity_pool/config.go
+++ b/config/confluent_identity_pool/config.go
@@ -1,0 +1,13 @@
+package confluent_identity_pool
+
+import "github.com/crossplane/upjet/pkg/config"
+
+// Configure configures individual resources by adding custom ResourceConfigurators.
+func Configure(p *config.Provider) {
+	p.AddResourceConfigurator("confluent_identity_pool", func(r *config.Resource) {
+		// We need to override the default group that upjet generated for
+		r.ShortGroup = "confluent"
+		r.UseAsync = true
+		r.Kind = "IdentityPool"
+	})
+}

--- a/config/external_name.go
+++ b/config/external_name.go
@@ -19,6 +19,7 @@ var ExternalNameConfigs = map[string]config.ExternalName{
 	"confluent_kafka_topic":          config.IdentifierFromProvider,
 	"confluent_role_binding":         config.IdentifierFromProvider,
 	"confluent_schema":               config.IdentifierFromProvider,
+	"confluent_identity_pool":        config.IdentifierFromProvider,
 }
 
 // ExternalNameConfigurations applies all external name configs listed in the

--- a/config/provider.go
+++ b/config/provider.go
@@ -16,6 +16,7 @@ import (
 	confluentkafkacluster "github.com/crossplane-contrib/provider-confluent/config/confluent_kafka_cluster"
 	confluentkafkaclusterconfig "github.com/crossplane-contrib/provider-confluent/config/confluent_kafka_cluster_config"
 	confluentkafkatopic "github.com/crossplane-contrib/provider-confluent/config/confluent_kafka_topic"
+	confluentidentitypool "github.com/crossplane-contrib/provider-confluent/config/confluent_identity_pool"
 	confluentrolebinding "github.com/crossplane-contrib/provider-confluent/config/confluent_role_binding"
 	confluentserviceaccount "github.com/crossplane-contrib/provider-confluent/config/confluent_service_account"
 )
@@ -50,6 +51,7 @@ func GetProvider() *ujconfig.Provider {
 		confluentapikey.Configure,
 		confluentkafkaacl.Configure,
 		confluentkafkatopic.Configure,
+		confluentidentitypool.Configure,
 		confluentrolebinding.Configure,
 	} {
 		configure(pc)


### PR DESCRIPTION
## Summary

- Add support for the `confluent_identity_pool` Terraform resource
- The resource was already present in the embedded Terraform schema and provider metadata but was not included in the provider's resource configuration

## Context

Identity Pools are used in Confluent Cloud to map external identities (e.g. mTLS client certificates) to Confluent principals via Identity Providers. This enables certificate-based authentication for external consumers without API keys.

Terraform resource reference: https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/confluent_identity_pool

## Changes

| File | Change |
|------|--------|
| `config/confluent_identity_pool/config.go` | New resource configurator (Kind: `IdentityPool`, ShortGroup: `confluent`) |
| `config/external_name.go` | Added `confluent_identity_pool` entry with `IdentifierFromProvider` |
| `config/provider.go` | Registered the configurator in the provider pipeline |

## Note

This PR only adds the resource configuration. The generated types and controller code need to be produced by running `make generate` as part of the CI/release pipeline. The pattern follows existing resources (e.g. `confluent_service_account`, `confluent_role_binding`).